### PR TITLE
Remove blank spaces on body

### DIFF
--- a/_sass/partials/_global.scss
+++ b/_sass/partials/_global.scss
@@ -5,6 +5,8 @@ body, html {
     font-weight: $regular;
     width: 100%;
     height: 100%;
+    margin: 0 auto;
+    padding: 0;
     background: $base-background-color;
     text-shadow: 1px 1px 1px rgba(0, 0, 0, .004);
     text-rendering: optimizeLegibility !important;


### PR DESCRIPTION
Añadido un margin de 0, auto y padding 0 en el body para evitar que aparezca el margen blanco por defecto alrededor de la web en Desktop